### PR TITLE
Ensure Readme.md is correct name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='phigaro',
 		'phigaro.to_html',
                 ],
       package_data = {
-        '': ['*.pickle', 'README.md']
+        '': ['*.pickle', 'Readme.md']
       },
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
Also pip does not seem to be synced with the latest repo:

```
$ sudo -H pip3 install phigaro
Collecting phigaro
  Downloading https://files.pythonhosted.org/packages/21/e9/863f9da4508ae1000f71224f5c391b4344de7c54c26ea719e83895cb5c52/phigaro-0.2.1.8.tar.gz (70kB)
     |████████████████████████████████| 71kB 2.0MB/s 
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/tmp/pip-install-2bdw4v97/phigaro/setup.py", line 2, in <module>
        with open("README.md", "r") as fh:
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /private/tmp/pip-install-2bdw4v97/phigaro/
```