### PR TITLE
fix pyYAML requirement; suggest no sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You also need `locate`. It is pre-installed in the latest Ubuntu distributions, 
 ## Installation
 
 ```
-sudo -H pip3 install phigaro
+pip3 install phigaro --user
 ```
 then create a config file with:
 ```

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(name='phigaro',
               'phigaro = phigaro.cli.batch:main',
               'phigaro-setup = phigaro.cli.helper:main',
           ]
-      }, install_requires=['numpy', 'six>=1.7.0', 'pandas>=0.23.4','sh', 'singleton', 'PyYAML', 'future', 'argparse', 'numpy', 'plotly', 'bs4', 'beautifulsoup4>=4.4.0', 'lxml','biopython']
+      }, install_requires=['numpy', 'six>=1.7.0', 'pandas>=0.23.4','sh', 'singleton', 'PyYAML>=5.1', 'future', 'argparse', 'numpy', 'plotly', 'bs4', 'beautifulsoup4>=4.4.0', 'lxml','biopython']
 )


### PR DESCRIPTION
I tried a completely fresh install and run of `phigaro`. It worked well mostly, but came up with these minor things. You're using `yaml.FullLoader`, which requires `PyYAML>=5.1` (otherwise you get: `AttributeError: module 'yaml' has no attribute 'FullLoader'`)

Also, I suggest we don't recommend to run `pip3` with `sudo`- there is no need now i think? 