### PR TITLE
Fix output path when not in the form -o dir/file

### DIFF
--- a/phigaro/cli/batch.py
+++ b/phigaro/cli/batch.py
@@ -122,7 +122,7 @@ def main():
 
     if config['phigaro']['output'] is not None:
         fold = os.path.dirname(config['phigaro']['output'])
-        if not os.path.isdir(fold):
+        if fold and not os.path.isdir(fold):
             os.makedirs(fold)
 
     Context.initialize(

--- a/phigaro/cli/batch.py
+++ b/phigaro/cli/batch.py
@@ -121,9 +121,9 @@ def main():
     )
 
     if config['phigaro']['output'] is not None:
-        fold = '/'.join(config['phigaro']['output'].replace('\\', '/').split('/')[:-1])
+        fold = os.path.dirname(config['phigaro']['output'])
         if not os.path.isdir(fold):
-            os.mkdir(fold)
+            os.makedirs(fold)
 
     Context.initialize(
         sample=sample,


### PR DESCRIPTION
Previously, the output file had to be specified in the form`-o dir/file` otherwise you got an error:
```
$ phigaro -f test_data/Bacillus_anthracis_str_ames.fna -o test -p --not-open
Traceback (most recent call last):
  File "/home/rands/miniconda3/envs/phigaro_env/bin/phigaro", line 8, in <module>
    sys.exit(main())
  File "/home/rands/miniconda3/envs/phigaro_env/lib/python3.7/site-packages/phigaro/cli/batch.py", line 126, in main
    os.mkdir(fold)
FileNotFoundError: [Errno 2] No such file or directory: ''
```

This fixes it for the case where only the file is specified, e.g. `-o test` or when there are multiple directories, e.g. `-o dir/subdir/test`