### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: phigaro_env
 dependencies:
-  - python=3.7
+  - python=3.7.0
   - pip
   - bioconda::prodigal
   - bioconda::hmmer


### PR DESCRIPTION
Pickle package is now considered to be unsafe. I guess that's the reason why it produces such an error message: "copyreg.py", line 43, in _reconstructor
    obj = object.__new__(cls) TypeError: object.__new__(BlockManager) is not safe, use BlockManager.__new__()". If you install phigaro with conda, it might use the most recent python 3.7. For example, for me it was Python 3.7.12 which produces this error. After editing the environment file to use python 3.7.0 this error disappeared.